### PR TITLE
6.6 velinux fix compile problem on x86

### DIFF
--- a/arch/x86/kernel/alternative.c
+++ b/arch/x86/kernel/alternative.c
@@ -1612,9 +1612,6 @@ void __init alternative_instructions(void)
 	 */
 	paravirt_set_cap();
 
-	/* Keep CET-IBT disabled until caller/callee are patched */
-	ibt = ibt_save(/*disable*/ true);
-
 	/*
 	 * First patch paravirt functions, such that we overwrite the indirect
 	 * call with the direct call.


### PR DESCRIPTION
This reverts the unrelated function changes that were accidentally merged in the previous patch, which caused compile error on x86 the platform.

Fixes: 6180febbe2a0 ("downstream: locking/qspinlock: Introduce CNA into the slow path of qspinlock")