### PR TITLE
downstream: vhost: fix -Werror=misleading-identation when enable CONF…

### DIFF
--- a/drivers/vhost/vhost.c
+++ b/drivers/vhost/vhost.c
@@ -2598,11 +2598,13 @@ int vhost_get_vq_desc(struct vhost_virtqueue *vq,
 
 	if (vq->avail_idx == vq->last_avail_idx) {
 		ret = vhost_get_avail_idx(vq);
-	if (unlikely(ret < 0))
-		return ret;
+		if (unlikely(ret < 0)) {
+			return ret;
+		}
 
-		if (!ret)
+		if (!ret) {
 			return vq->num;
+		}
 	}
 
 	/* Grab the next descriptor number they're advertising, and increment


### PR DESCRIPTION
downstream: vhost: fix -Werror=misleading-identation when enable CONFIG_WERROR

fix("0e167262b11d downstream: vhost: move smp_rmb() into vhost_get_avail_idx()")