### PR TITLE
downstream: cpufreq: CPPC: Don't warn on failing to read perf counters on offline cpus

### DIFF
--- a/drivers/cpufreq/cppc_cpufreq.c
+++ b/drivers/cpufreq/cppc_cpufreq.c
@@ -171,16 +171,14 @@ static void cppc_cpufreq_cpu_fie_init(struct cpufreq_policy *policy)
 		init_irq_work(&cppc_fi->irq_work, cppc_irq_work);
 
 		ret = cppc_get_perf_ctrs(cpu, &cppc_fi->prev_perf_fb_ctrs);
-		if (ret) {
-			pr_warn("%s: failed to read perf counters for cpu:%d: %d\n",
-				__func__, cpu, ret);
-
+		if (ret && cpu_online(cpu)) {
 			/*
 			 * Don't abort if the CPU was offline while the driver
 			 * was getting registered.
 			 */
-			if (cpu_online(cpu))
-				return;
+			pr_debug("%s: failed to read perf counters for cpu:%d: %d\n",
+				__func__, cpu, ret);
+			return;
 		}
 	}
 


### PR DESCRIPTION
downstream: cpufreq: CPPC: Don't warn on failing to read perf counters on offline cpus
Reading perf counters on offline cpus should be expected to fail, e.g. it
returns -EFAULT as counters are shown to be 0.  Remove the unnecessary
warning print on this failure path.

Fixes: https://github.com/Lostwayzxc/kernel/commit/1eb5dde674f57b1a1918dab33f09e35cdd64eb07 ("cpufreq: CPPC: Add support for frequency invariance")
Signed-off-by: Jie Zhan <zhanjie9@hisilicon.com>
Signed-off-by: Hongye Lin <linhongye@h-partners.com>
Signed-off-by: chenyi <chenyi211@h-partners.com>
Signed-off-by: Cao Jiaqiang <caojiaqiang@huawei.com>